### PR TITLE
Fixe a checkbox input for newsletter on ios

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -45,7 +45,7 @@
         required
         [disabled]="loading || sent">
 
-        <div class="my-3 pretty p-svg p-plain p-bigger p-smooth text-sm text-light" [class.d-none]="sent">
+        <div class="my-3 pretty p-svg p-plain p-bigger p-rotate text-sm text-light" [class.d-none]="sent">
           <input
           type="checkbox"
           (change)="onAccept($event.srcElement.checked)"


### PR DESCRIPTION
On **ios devices**, the checkbox for the newsletter in the _footer_ was hidden whenever we click on it.
#12 